### PR TITLE
Feature/rtf-14

### DIFF
--- a/__mocks__/@tensorflow/tfjs/index.js
+++ b/__mocks__/@tensorflow/tfjs/index.js
@@ -5,11 +5,21 @@ module.exports = {
   dispose: jest.fn(),
   loadGraphModel: () =>
     new Promise(resolve =>
-      resolve({ name: 'TF Graph Model', predict: v => v })
+      resolve({
+        name: 'TF Graph Model',
+        predict: v => v,
+        execute: v => v,
+        outputs: [{ name: 'output_layer' }]
+      })
     ),
   loadLayersModel: () =>
     new Promise(resolve =>
-      resolve({ name: 'TF Layer Model', predict: v => v })
+      resolve({
+        name: 'TF Layer Model',
+        predict: v => v,
+        execute: v => v,
+        outputs: [{ name: 'output_layer' }]
+      })
     ),
   data: {
     ...tf.data,

--- a/__test__/codeConform.test.ts
+++ b/__test__/codeConform.test.ts
@@ -14,9 +14,5 @@ test('code conforms', async () => {
     }) => errorCount + warningCount > 0
   )
 
-  if (results.length > 0) {
-    console.log(results)
-  }
-
   expect(results).toEqual([])
 })

--- a/src/hooks/__test__/useModel.test.tsx
+++ b/src/hooks/__test__/useModel.test.tsx
@@ -9,13 +9,16 @@ import useModel from '../useModel'
 describe('useModel Hook', () => {
   const acceptedModelUrls = [
     'https://tfhub.dev/google/tfjs-model/imagenet/inception_v3/classification/3/default/1',
-    'https://tfhub.dev/tensorflow/tfjs-model/universal-sentence-encoder-lite/1/default/1'
+    'file://../../api/model/model.json'
   ]
+
   const notAcceptedModelsUrls = [
     'https://www.google.com',
     '1uibiwfbjnwe',
     './../../model/model.json'
   ]
+
+  jest.spyOn(console, 'error')
 
   acceptedModelUrls.forEach(url => {
     test(`Returns model using ${url}`, async () => {
@@ -28,10 +31,11 @@ describe('useModel Hook', () => {
     })
   })
 
-  notAcceptedModelsUrls.forEach((url: string) => {
+  notAcceptedModelsUrls.forEach((url: string, i) => {
     test(`Won't return model using ${url}`, () => {
       const { result } = renderHook(() => useModel({ modelUrl: url }))
       expect(result.current).toBeNull()
+      expect(console.error).toHaveBeenCalledTimes(i + 1)
     })
   })
 
@@ -44,7 +48,7 @@ describe('useModel Hook', () => {
     expect(result.current).toMatchObject({ name: 'TF Layer Model' })
   })
 
-  test('If not passed url, the model should use the Model Context', async () => {
+  test('If not passed a model, the model should use the Model Context', async () => {
     const wrapper: React.FC<{ children: React.ComponentType }> = ({
       children
     }) => (

--- a/src/hooks/__test__/useWebcam.test.tsx
+++ b/src/hooks/__test__/useWebcam.test.tsx
@@ -40,8 +40,6 @@ describe('useWebcam', () => {
     const VideoComponent: React.FC = () => {
       const [ref, tensor] = useWebcam()
 
-      console.log(tensor)
-
       return (
         <div>
           <video width={150} height={150} ref={ref} />

--- a/src/hooks/useModel.ts
+++ b/src/hooks/useModel.ts
@@ -18,15 +18,14 @@ export default function useModel ({
   React.useEffect(() => {
     const getModel = async (): Promise<void> => {
       const loadedModel = await loadModel(modelUrl, opts)
-      if (loadedModel !== null) {
-        setModel(loadedModel)
-      }
+      setModel(loadedModel)
     }
 
     const loadNodeModel = async (): Promise<void> => {
       const loadedModel = await modelObj.load()
       setModel(loadedModel)
     }
+
     if (modelUrl !== undefined) {
       void getModel()
     } else if (modelObj !== undefined) {

--- a/src/hooks/usePrediction.ts
+++ b/src/hooks/usePrediction.ts
@@ -2,41 +2,50 @@ import * as React from 'react'
 import * as tf from '@tensorflow/tfjs'
 
 import {
-  UsePredictionOptions,
+  UsePredictionProps,
   Prediction,
   GraphModel,
-  LayersModel
+  LayersModel,
+  PredictionReturn
 } from 'types/index'
 
 import useModel from './useModel'
 import useDataRef from './useDataRef'
 
-let T: [React.MutableRefObject<tf.Tensor | null>, Prediction]
-
 export default function usePrediction ({
-  modelUrl
-}: UsePredictionOptions = {}): typeof T {
+  predictConfig,
+  usePredict,
+  ...props
+}: UsePredictionProps = {}): typeof PredictionReturn {
   const [prediction, setPrediction] = React.useState<Prediction>(null)
-  const model = useModel({ modelUrl })
+  const model = useModel({ ...props })
   const dataRef = React.useRef<tf.Tensor | null>(null)
   const data = useDataRef(dataRef)
 
   React.useEffect(() => {
     if (model !== null && data !== null) {
-      void Promise.resolve(getPrediction(model, data)).then(
-        (prediction: tf.Tensor | tf.Tensor[] | tf.NamedTensorMap | null) =>
-          setPrediction(prediction)
-      )
+      void Promise.resolve(
+        getPrediction(model, data, predictConfig, usePredict)
+      ).then(prediction => setPrediction(prediction))
     }
   }, [model, data, prediction])
 
   return [dataRef, prediction]
 }
 
-const getPrediction = async (
+const getPrediction = (
   model: GraphModel | LayersModel,
-  data: tf.Tensor
-): Promise<Prediction> => {
-  const prediction = await model.predict(data, {})
-  return prediction
+  data: tf.Tensor,
+  predictConfig?: tf.ModelPredictConfig,
+  usePredict = false
+): Prediction => {
+  if (predictConfig !== undefined || usePredict) {
+    return model.predict(data, {
+      batchSize: 32,
+      verbose: false,
+      ...predictConfig
+    })
+  } else {
+    return model.execute(data, model.outputs[0].name)
+  }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,8 +30,11 @@ export interface AttachWebcamOptions extends MediaStreamConstraints {
   facingMode?: string
 }
 
-export interface UsePredictionOptions {
-  modelUrl?: string
+export interface UsePredictionProps extends UseModelProps {
+  predictConfig?: tf.ModelPredictConfig
+  usePredict?: boolean
 }
 
 export type Prediction = tf.Tensor | tf.Tensor[] | tf.NamedTensorMap | null
+
+export let PredictionReturn: [React.MutableRefObject<tf.Tensor | null>, Prediction]


### PR DESCRIPTION
tests: don't print results from codeConform if there are errors.
test: check error call on notAcceptedModelsUrls
feature: usePrediction should use .execute by default but can use .predict if config or flag is present – closes #14