### PR TITLE
Spike/rtf 15

### DIFF
--- a/__mocks__/@tensorflow/tfjs/index.ts
+++ b/__mocks__/@tensorflow/tfjs/index.ts
@@ -1,4 +1,12 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/promise-function-async */
 import * as tf from '@tensorflow/tfjs'
+
+const modelSharedProperties = {
+  predict: (v: any) => v,
+  execute: (v: any) => v,
+  outputs: [{ name: 'output_layer' }]
+}
 
 module.exports = {
   ...tf,
@@ -7,18 +15,14 @@ module.exports = {
     new Promise(resolve =>
       resolve({
         name: 'TF Graph Model',
-        predict: v => v,
-        execute: v => v,
-        outputs: [{ name: 'output_layer' }]
+        ...modelSharedProperties
       })
     ),
   loadLayersModel: () =>
     new Promise(resolve =>
       resolve({
         name: 'TF Layer Model',
-        predict: v => v,
-        execute: v => v,
-        outputs: [{ name: 'output_layer' }]
+        ...modelSharedProperties
       })
     ),
   data: {

--- a/src/hooks/__test__/usePrediction.test.ts
+++ b/src/hooks/__test__/usePrediction.test.ts
@@ -26,7 +26,7 @@ describe('usePrediction', () => {
 
     await waitForNextUpdate()
 
-    expect(result.current[1]).toBe(expected)
+    expect(result.current[1]).toBe(expected.dataSync())
   })
 
   it('should use .predict if a predict boolean is passed', async () => {

--- a/src/hooks/__test__/usePrediction.test.ts
+++ b/src/hooks/__test__/usePrediction.test.ts
@@ -28,4 +28,29 @@ describe('usePrediction', () => {
 
     expect(result.current[1]).toBe(expected)
   })
+
+  it('should use .predict if a predict boolean is passed', async () => {
+    const mockPredict = jest.fn().mockImplementation(v => v)
+
+    const expected = tf.tensor([1, 2, 3, 4])
+    const promise = new Promise(resolve =>
+      resolve({
+        predict: mockPredict
+      })
+    )
+
+    const { waitForNextUpdate } = renderHook(() => {
+      const arr = usePrediction({
+        model: {
+          load: async () => await promise
+        },
+        usePredict: true
+      })
+      arr[0].current = expected
+      return arr
+    })
+
+    await waitForNextUpdate()
+    expect(mockPredict).toHaveBeenCalled()
+  })
 })

--- a/src/hooks/usePrediction.ts
+++ b/src/hooks/usePrediction.ts
@@ -17,7 +17,7 @@ export default function usePrediction ({
   usePredict,
   ...props
 }: UsePredictionProps = {}): typeof PredictionReturn {
-  const [prediction, setPrediction] = React.useState<Prediction>(null)
+  const [prediction, setPrediction] = React.useState<Float32Array | null>(null)
   const model = useModel({ ...props })
   const dataRef = React.useRef<tf.Tensor | null>(null)
   const data = useDataRef(dataRef)
@@ -26,7 +26,12 @@ export default function usePrediction ({
     if (model !== null && data !== null) {
       void Promise.resolve(
         getPrediction(model, data, predictConfig, usePredict)
-      ).then(prediction => setPrediction(prediction))
+      )
+        .then(
+          async prediction =>
+            (await (prediction as tf.Tensor).data()) as Float32Array
+        )
+        .then(data => setPrediction(data))
     }
   }, [model, data, prediction])
 

--- a/src/hooks/usePrediction.ts
+++ b/src/hooks/usePrediction.ts
@@ -40,11 +40,7 @@ const getPrediction = (
   usePredict = false
 ): Prediction => {
   if (predictConfig !== undefined || usePredict) {
-    return model.predict(data, {
-      batchSize: 32,
-      verbose: false,
-      ...predictConfig
-    })
+    return model.predict(data, predictConfig)
   } else {
     return model.execute(data, model.outputs[0].name)
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,6 @@
 import * as tf from '@tensorflow/tfjs'
 
-export interface GraphModel extends tf.InferenceModel {
+export interface GraphModel extends tf.GraphModel {
   name?: string
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -37,4 +37,4 @@ export interface UsePredictionProps extends UseModelProps {
 
 export type Prediction = tf.Tensor | tf.Tensor[] | tf.NamedTensorMap | null
 
-export let PredictionReturn: [React.MutableRefObject<tf.Tensor | null>, Prediction]
+export let PredictionReturn: [React.MutableRefObject<tf.Tensor | null>, Float32Array | null]


### PR DESCRIPTION
tests: cover using the prediction flag
change: usePrediction should return a Float32Array not a tensor 

closes: #15 